### PR TITLE
Fix order execution quantity handling

### DIFF
--- a/alembic/versions/1a2b3c4d5e6f_change_quantity_to_float.py
+++ b/alembic/versions/1a2b3c4d5e6f_change_quantity_to_float.py
@@ -1,0 +1,23 @@
+"""Change quantity column to Float
+
+Revision ID: 1a2b3c4d5e6f
+Revises: c2947bcd2648
+Create Date: 2025-06-30 00:00:00.000000
+"""
+
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "1a2b3c4d5e6f"
+down_revision: Union[str, Sequence[str], None] = "c2947bcd2648"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column("signals", "quantity", existing_type=sa.Integer(), type_=sa.Float())
+
+
+def downgrade() -> None:
+    op.alter_column("signals", "quantity", existing_type=sa.Float(), type_=sa.Integer())

--- a/app/models/signal.py
+++ b/app/models/signal.py
@@ -11,8 +11,10 @@ class Signal(Base):
     id = Column(Integer, primary_key=True, index=True)
     symbol = Column(String(10), nullable=False, index=True)
     action = Column(String(10), nullable=False)  # buy, sell
-    strategy_id = Column(String(50), nullable=False, index=True)  # NUEVO: identificador de estrategia
-    quantity = Column(Integer, nullable=True)
+    strategy_id = Column(
+        String(50), nullable=False, index=True
+    )  # NUEVO: identificador de estrategia
+    quantity = Column(Float, nullable=True)
     price = Column(Float, nullable=True)
     source = Column(String(50), default="tradingview")
     timestamp = Column(DateTime, server_default=func.now())
@@ -21,9 +23,13 @@ class Signal(Base):
     error_message = Column(Text, nullable=True)
 
     # Campos para análisis avanzado
-    reason = Column(String(50), nullable=True)  # fibonacci_entry, fibonacci_exit, trailing_stop
+    reason = Column(
+        String(50), nullable=True
+    )  # fibonacci_entry, fibonacci_exit, trailing_stop
     confidence = Column(Integer, nullable=True)  # Score 0-100
-    tv_timestamp = Column(String(50), nullable=True)  # Timestamp original de TradingView
+    tv_timestamp = Column(
+        String(50), nullable=True
+    )  # Timestamp original de TradingView
 
     def __repr__(self):
         return f"<Signal({self.strategy_id}:{self.symbol}, {self.action}, {self.status}, conf:{self.confidence})>"

--- a/app/schemas/webhook.py
+++ b/app/schemas/webhook.py
@@ -8,7 +8,7 @@ class TradingViewWebhook(BaseModel):
     symbol: str
     action: str  # "buy" or "sell"
     strategy_id: str  # Identificador único de la estrategia
-    quantity: Optional[int] = None
+    quantity: Optional[float] = None
     price: Optional[float] = None
     message: Optional[str] = None
 

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -42,7 +42,9 @@ class PositionManager:
 
         # Si ya tenemos el símbolo, no cuenta como nueva posición
         if current_qty == 0 and current_positions >= self.max_positions:
-            raise ValueError(f"Maximum positions limit reached ({self.max_positions}). Current: {current_positions}")
+            raise ValueError(
+                f"Maximum positions limit reached ({self.max_positions}). Current: {current_positions}"
+            )
 
         # 2. Verificar efectivo disponible
         account = self.alpaca.get_account()
@@ -58,7 +60,9 @@ class PositionManager:
             estimated_cost = float(quote.price) * calculated_quantity
 
             if estimated_cost > available_cash:
-                raise ValueError(f"Insufficient cash. Need: ${estimated_cost:.2f}, Available: ${available_cash:.2f}")
+                raise ValueError(
+                    f"Insufficient cash. Need: ${estimated_cost:.2f}, Available: ${available_cash:.2f}"
+                )
 
         except Exception as e:
             logger.warning(f"Could not validate cash for {signal.symbol}: {e}")
@@ -76,7 +80,8 @@ class PositionManager:
         # 2. Verificar que no vendemos más de lo que tenemos
         if calculated_quantity > current_qty:
             raise ValueError(
-                f"Cannot sell {calculated_quantity} shares. Only have {current_qty} shares of {signal.symbol}")
+                f"Cannot sell {calculated_quantity} shares. Only have {current_qty} shares of {signal.symbol}"
+            )
 
         return True
 
@@ -89,14 +94,16 @@ class PositionManager:
 
         # Si intentamos vender más de lo que tenemos, vender todo
         if calculated_quantity > current_qty:
-            logger.warning(f"Adjusting sell quantity for {signal.symbol}: {calculated_quantity} -> {current_qty}")
+            logger.warning(
+                f"Adjusting sell quantity for {signal.symbol}: {calculated_quantity} -> {current_qty}"
+            )
             return current_qty
 
         return calculated_quantity
 
     def is_crypto(self, symbol):
         """Verificar si es crypto"""
-        return '/' in symbol or symbol.endswith('USD')
+        return "/" in symbol or symbol.endswith("USD")
 
     def get_portfolio_summary(self):
         """Resumen del portafolio"""
@@ -111,7 +118,7 @@ class PositionManager:
                 "cash": float(account.cash),
                 "portfolio_value": float(account.portfolio_value),
                 "buying_power": float(account.buying_power),
-                "positions": positions
+                "positions": positions,
             }
         except Exception as e:
             logger.error(f"Error getting portfolio summary: {e}")
@@ -120,60 +127,3 @@ class PositionManager:
 
 # Instancia global
 position_manager = PositionManager()
-
-# ACTUALIZACIÓN NECESARIA EN order_executor.py
-# Agregar estas importaciones y modificaciones:
-
-from .position_manager import position_manager
-
-
-class OrderExecutor:
-    def __init__(self):
-        self.alpaca = alpaca_client
-        self.position_manager = position_manager
-
-    # ... métodos existentes ...
-
-    def execute_signal(self, signal: Signal):
-        """Ejecutar señal en Alpaca con validaciones de posición"""
-        try:
-            # Calcular cantidad si no se especificó
-            if not signal.quantity:
-                signal.quantity = self.calculate_position_size(signal.symbol, signal.action)
-
-            # VALIDACIONES CRÍTICAS DE POSICIÓN
-            if signal.action.lower() == 'buy':
-                # Validar señal de compra
-                self.position_manager.validate_buy_signal(signal, signal.quantity)
-
-            elif signal.action.lower() == 'sell':
-                # Validar y ajustar señal de venta
-                self.position_manager.validate_sell_signal(signal, signal.quantity)
-                signal.quantity = self.position_manager.adjust_sell_quantity(signal, signal.quantity)
-
-            # Enviar orden según el tipo de activo
-            if self.is_crypto(signal.symbol):
-                order = self.alpaca.submit_crypto_order(
-                    symbol=signal.symbol,
-                    qty=signal.quantity,
-                    side=signal.action
-                )
-            else:
-                order = self.alpaca.submit_order(
-                    symbol=signal.symbol,
-                    qty=signal.quantity,
-                    side=signal.action
-                )
-
-            # Actualizar señal con resultado
-            signal.status = "processed"
-            signal.error_message = None
-
-            logger.info(f"Order submitted: {order.id} for {signal.symbol} (crypto: {self.is_crypto(signal.symbol)})")
-            return order
-
-        except Exception as e:
-            signal.status = "error"
-            signal.error_message = str(e)
-            logger.error(f"Error executing signal for {signal.symbol}: {e}")
-            raise


### PR DESCRIPTION
## Summary
- allow fractional quantities for order signals
- remove outdated `OrderExecutor` code from `position_manager`
- add Alembic migration for `signals.quantity` column

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_686747404a508331a149f545ce049791