### PR TITLE
Fix sell logic to close strategy positions

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -132,7 +132,9 @@ class OrderExecutor:
         if strategy_position.quantity <= 0:
             raise ValueError(f"Strategy {signal.strategy_id} has no position in {signal.symbol} to sell")
 
-        quantity_to_sell = min(signal.quantity, strategy_position.quantity)
+        # Sell signal should close the entire position for this strategy
+        # regardless of the quantity provided in the webhook
+        quantity_to_sell = strategy_position.quantity
         signal.quantity = quantity_to_sell
 
         mapped_symbol = self.map_symbol_to_alpaca(signal.symbol)


### PR DESCRIPTION
## Summary
- adjust sell signal flow to liquidate entire strategy position for that symbol

## Testing
- `python -m py_compile app/services/order_executor.py`


------
https://chatgpt.com/codex/tasks/task_e_68674a0661ec833185157c1401786bec