### PR TITLE
Share symbol mapping between services

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -7,6 +7,7 @@ from ..config import settings
 from .position_manager import position_manager
 from .strategy_position_manager import StrategyPositionManager
 from ..database import get_db
+from ..utils.symbols import map_symbol_to_alpaca
 import logging
 
 logger = logging.getLogger(__name__)
@@ -21,13 +22,6 @@ class OrderExecutor:
         """Verificar si es un símbolo de crypto"""
         return '/' in symbol or symbol.endswith('USD')
 
-    def map_symbol_to_alpaca(self, symbol):
-        """Convertir símbolos de TradingView a formato Alpaca"""
-        symbol_map = {
-            'BTCUSD': 'BTC/USD',
-            'ETHUSD': 'ETH/USD',
-        }
-        return symbol_map.get(symbol, symbol)
 
     def calculate_position_size(self, symbol, action):
         """Calcular tamaño de posición (10% del capital)"""
@@ -38,7 +32,7 @@ class OrderExecutor:
         position_value = buying_power * 0.10
 
         # Obtener precio actual
-        mapped_symbol = self.map_symbol_to_alpaca(symbol)
+        mapped_symbol = map_symbol_to_alpaca(symbol)
         if self.is_crypto(symbol):
             quote = self.alpaca.get_latest_crypto_quote(mapped_symbol)
         else:
@@ -92,7 +86,7 @@ class OrderExecutor:
         account = self.alpaca.get_account()
         available_cash = float(account.cash)
 
-        mapped_symbol = self.map_symbol_to_alpaca(signal.symbol)
+        mapped_symbol = map_symbol_to_alpaca(signal.symbol)
         if self.is_crypto(signal.symbol):
             quote = self.alpaca.get_latest_crypto_quote(mapped_symbol)
         else:
@@ -135,7 +129,7 @@ class OrderExecutor:
         quantity_to_sell = min(signal.quantity, strategy_position.quantity)
         signal.quantity = quantity_to_sell
 
-        mapped_symbol = self.map_symbol_to_alpaca(signal.symbol)
+        mapped_symbol = map_symbol_to_alpaca(signal.symbol)
         if self.is_crypto(signal.symbol):
             order = self.alpaca.submit_crypto_order(
                 symbol=mapped_symbol,

--- a/app/services/position_manager.py
+++ b/app/services/position_manager.py
@@ -2,6 +2,7 @@
 
 from ..integrations.alpaca.client import alpaca_client
 from ..models.signal import Signal
+from ..utils.symbols import map_symbol_to_alpaca
 import logging
 
 logger = logging.getLogger(__name__)
@@ -24,7 +25,8 @@ class PositionManager:
     def get_position_quantity(self, symbol):
         """Obtener cantidad específica de un símbolo"""
         try:
-            position = self.alpaca.get_position(symbol)
+            mapped_symbol = map_symbol_to_alpaca(symbol)
+            position = self.alpaca.get_position(mapped_symbol)
             return float(position.qty) if position else 0.0
         except Exception:
             return 0.0
@@ -120,60 +122,3 @@ class PositionManager:
 
 # Instancia global
 position_manager = PositionManager()
-
-# ACTUALIZACIÓN NECESARIA EN order_executor.py
-# Agregar estas importaciones y modificaciones:
-
-from .position_manager import position_manager
-
-
-class OrderExecutor:
-    def __init__(self):
-        self.alpaca = alpaca_client
-        self.position_manager = position_manager
-
-    # ... métodos existentes ...
-
-    def execute_signal(self, signal: Signal):
-        """Ejecutar señal en Alpaca con validaciones de posición"""
-        try:
-            # Calcular cantidad si no se especificó
-            if not signal.quantity:
-                signal.quantity = self.calculate_position_size(signal.symbol, signal.action)
-
-            # VALIDACIONES CRÍTICAS DE POSICIÓN
-            if signal.action.lower() == 'buy':
-                # Validar señal de compra
-                self.position_manager.validate_buy_signal(signal, signal.quantity)
-
-            elif signal.action.lower() == 'sell':
-                # Validar y ajustar señal de venta
-                self.position_manager.validate_sell_signal(signal, signal.quantity)
-                signal.quantity = self.position_manager.adjust_sell_quantity(signal, signal.quantity)
-
-            # Enviar orden según el tipo de activo
-            if self.is_crypto(signal.symbol):
-                order = self.alpaca.submit_crypto_order(
-                    symbol=signal.symbol,
-                    qty=signal.quantity,
-                    side=signal.action
-                )
-            else:
-                order = self.alpaca.submit_order(
-                    symbol=signal.symbol,
-                    qty=signal.quantity,
-                    side=signal.action
-                )
-
-            # Actualizar señal con resultado
-            signal.status = "processed"
-            signal.error_message = None
-
-            logger.info(f"Order submitted: {order.id} for {signal.symbol} (crypto: {self.is_crypto(signal.symbol)})")
-            return order
-
-        except Exception as e:
-            signal.status = "error"
-            signal.error_message = str(e)
-            logger.error(f"Error executing signal for {signal.symbol}: {e}")
-            raise

--- a/app/utils/symbols.py
+++ b/app/utils/symbols.py
@@ -1,0 +1,14 @@
+"""Utility functions for symbol conversions."""
+
+from typing import Dict
+
+# Mapping from TradingView format to Alpaca format
+_SYMBOL_MAP: Dict[str, str] = {
+    'BTCUSD': 'BTC/USD',
+    'ETHUSD': 'ETH/USD',
+}
+
+
+def map_symbol_to_alpaca(symbol: str) -> str:
+    """Map TradingView symbols to Alpaca symbols."""
+    return _SYMBOL_MAP.get(symbol, symbol)


### PR DESCRIPTION
## Summary
- create `map_symbol_to_alpaca` utility
- use shared mapping in `OrderExecutor`
- convert symbol in `PositionManager.get_position_quantity`
- remove leftover code from `position_manager.py`

## Testing
- `pytest -q`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_68674d29528c83318efab26c88015ce7