### PR TITLE
Remove unused imports in order_executor.py

### DIFF
--- a/app/services/order_executor.py
+++ b/app/services/order_executor.py
@@ -1,9 +1,7 @@
 # backend/app/services/order_executor.py
 
-from sqlalchemy.orm import Session
 from ..integrations.alpaca.client import alpaca_client
 from ..models.signal import Signal
-from ..config import settings
 from .position_manager import position_manager
 from .strategy_position_manager import StrategyPositionManager
 from ..database import get_db


### PR DESCRIPTION
## Summary
- cleanup unused imports in `order_executor`

## Testing
- `flake8 app/services/order_executor.py`

------
https://chatgpt.com/codex/tasks/task_e_686753a7dbb48331b8a5990b73ecd64b